### PR TITLE
EVSRESTAPI-509 fhir r5 sdk examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ This is an easy-to-use tutorial for accessing EVSRESTAPI APIs.
 
 ## Tutorials by Language
 
-- [Click for Bash examples.](./bash-examples/ "Bash Examples")
-- [Click for Curl examples.](./curl-examples/ "Curl Examples")
-- [Click for Java examples.](./java-examples/ "Java Examples")
-- [Click for Postman examples.](./postman-examples/ "Postman Examples")
-- [Click for Python examples.](./python-examples/ "Python Examples")
-- [Click for Go examples.](./go-examples/ "Go Examples")
-- [Click for Typescript examples.](./typescript-examples/ "TypeScript Examples")
+- [Click for Bash examples.](../master/bash-examples/ "Bash Examples")
+- [Click for Curl examples.](../master/curl-examples/ "Curl Examples")
+- [Click for FHIR examples.](../master/fhir-examples/ "Fhir Examples")
+- [Click for Go examples.](../master/go-examples/ "Go Examples")
+- [Click for Java examples.](../master/java-examples/ "Java Examples")
+- [Click for Postman examples.](../master/postman-examples/ "Postman Examples")
+- [Click for Python examples.](../master/python-examples/ "Python Examples")
+- [Click for Typescript examples.](../master/typescript-examples/ "Typescript Examples")
 
 **[Back to top](#table-of-contents)**
 

--- a/fhir-examples/EVSRESTAPI-FHIR-R4.postman_collection.json
+++ b/fhir-examples/EVSRESTAPI-FHIR-R4.postman_collection.json
@@ -351,7 +351,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ValueSet/ncit_c54585",
+							"raw": "{{baseUrl}}/fhir/r4/ValueSet/ncit_C54585",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -359,7 +359,7 @@
 								"fhir",
 								"r4",
 								"ValueSet",
-								"ncit_c54585"
+								"ncit_C54585"
 							],
 							"query": [
 								{
@@ -379,7 +379,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ValueSet?_id=ncit_c54585",
+							"raw": "{{baseUrl}}/fhir/r4/ValueSet?_id=ncit_C54585",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -396,7 +396,7 @@
 								},
 								{
 									"key": "_id",
-									"value": "ncit_c54585"
+									"value": "ncit_C54585"
 								}
 							]
 						},
@@ -710,7 +710,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ConceptMap/$translate?code=C19939&reverse=true",
+							"raw": "{{baseUrl}}/fhir/r4/ConceptMap/$translate?code=c19939&reverse=true",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -727,7 +727,7 @@
 								},
 								{
 									"key": "code",
-									"value": "C19939"
+									"value": "c19939"
 								},
 								{
 									"key": "reverse",
@@ -744,7 +744,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ConceptMap//GO_to_NCIt_Mapping_February2020/$translate?code=C19939&reverse=true",
+							"raw": "{{baseUrl}}/fhir/r4/ConceptMap//GO_to_NCIt_Mapping_February2020/$translate?code=c19939&reverse=true",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -763,7 +763,7 @@
 								},
 								{
 									"key": "code",
-									"value": "C19939"
+									"value": "c19939"
 								},
 								{
 									"key": "reverse",

--- a/fhir-examples/EVSRESTAPI-FHIR-R4.postman_collection.json
+++ b/fhir-examples/EVSRESTAPI-FHIR-R4.postman_collection.json
@@ -107,7 +107,7 @@
 					"response": []
 				},
 				{
-					"name": "Find code systems by system url",
+					"name": "Find code systems by url",
 					"request": {
 						"method": "GET",
 						"header": [],
@@ -351,7 +351,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ValueSet/ncit_C54585",
+							"raw": "{{baseUrl}}/fhir/r4/ValueSet/ncit_c54585",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -359,7 +359,7 @@
 								"fhir",
 								"r4",
 								"ValueSet",
-								"ncit_C54585"
+								"ncit_c54585"
 							],
 							"query": [
 								{
@@ -379,7 +379,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ValueSet?_id=ncit_C54585",
+							"raw": "{{baseUrl}}/fhir/r4/ValueSet?_id=ncit_c54585",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -396,7 +396,7 @@
 								},
 								{
 									"key": "_id",
-									"value": "ncit_C54585"
+									"value": "ncit_c54585"
 								}
 							]
 						},
@@ -436,7 +436,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ValueSet/ncit_C54585/$validate-code?code=C20821",
+							"raw": "{{baseUrl}}/fhir/r4/ValueSet/ncit_c54585/$validate-code?code=C20821",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -444,7 +444,7 @@
 								"fhir",
 								"r4",
 								"ValueSet",
-								"ncit_C54585",
+								"ncit_c54585",
 								"$validate-code"
 							],
 							"query": [
@@ -579,7 +579,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ConceptMap/GO_to_NCIt_Mapping_February2020",
+							"raw": "{{baseUrl}}/fhir/r4/ConceptMap/go_to_ncit_mapping_february2020",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -587,7 +587,7 @@
 								"fhir",
 								"r4",
 								"ConceptMap",
-								"GO_to_NCIt_Mapping_February2020"
+								"go_to_ncit_mapping_february2020"
 							]
 						}
 					},
@@ -599,7 +599,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/fhir/r4/ConceptMap?_id=GO_to_NCIt_Mapping_February2020",
+							"raw": "{{baseUrl}}/fhir/r4/ConceptMap?_id=go_to_ncit_mapping_february2020",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -611,7 +611,7 @@
 							"query": [
 								{
 									"key": "_id",
-									"value": "GO_to_NCIt_Mapping_February2020"
+									"value": "go_to_ncit_mapping_february2020"
 								}
 							]
 						}
@@ -661,6 +661,10 @@
 							],
 							"query": [
 								{
+									"key": "system",
+									"value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+								},
+								{
 									"key": "code",
 									"value": "GO:0016887"
 								}
@@ -688,6 +692,10 @@
 							],
 							"query": [
 								{
+									"key": "url",
+									"value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+								},
+								{
 									"key": "code",
 									"value": "GO:0016887"
 								}
@@ -713,6 +721,10 @@
 								"$translate"
 							],
 							"query": [
+								{
+									"key": "system",
+									"value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+								},
 								{
 									"key": "code",
 									"value": "C19939"
@@ -745,6 +757,10 @@
 								"$translate"
 							],
 							"query": [
+								{
+									"key": "url",
+									"value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+								},
 								{
 									"key": "code",
 									"value": "C19939"

--- a/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
+++ b/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
@@ -107,7 +107,7 @@
           "response": []
         },
         {
-          "name": "Find code systems by system url",
+          "name": "Find code systems by url",
           "request": {
             "method": "GET",
             "header": [],
@@ -351,7 +351,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_C54585",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_c54585",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -359,7 +359,7 @@
                 "fhir",
                 "r5",
                 "ValueSet",
-                "ncit_C54585"
+                "ncit_c54585"
               ],
               "query": [
                 {
@@ -379,7 +379,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet?_id=ncit_C54585",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet?_id=ncit_c54585",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -396,7 +396,7 @@
                 },
                 {
                   "key": "_id",
-                  "value": "ncit_C54585"
+                  "value": "ncit_c54585"
                 }
               ]
             },
@@ -436,7 +436,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_C54585/$validate-code?code=C20821",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_c54585/$validate-code?code=C20821",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -444,7 +444,7 @@
                 "fhir",
                 "r5",
                 "ValueSet",
-                "ncit_C54585",
+                "ncit_c54585",
                 "$validate-code"
               ],
               "query": [
@@ -579,7 +579,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/GO_to_NCIt_Mapping_February2020",
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/go_to_ncit_mapping_february2020",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -587,7 +587,7 @@
                 "fhir",
                 "r5",
                 "ConceptMap",
-                "GO_to_NCIt_Mapping_February2020"
+                "go_to_ncit_mapping_february2020"
               ]
             }
           },
@@ -599,7 +599,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ConceptMap?_id=GO_to_NCIt_Mapping_February2020",
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap?_id=go_to_ncit_mapping_february2020",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -611,7 +611,7 @@
               "query": [
                 {
                   "key": "_id",
-                  "value": "GO_to_NCIt_Mapping_February2020"
+                  "value": "go_to_ncit_mapping_february2020"
                 }
               ]
             }
@@ -661,6 +661,10 @@
               ],
               "query": [
                 {
+                  "key": "system",
+                  "value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+                },
+                {
                   "key": "code",
                   "value": "GO:0016887"
                 }
@@ -675,7 +679,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/GO_to_NCIt_Mapping_February2020/$translate?code=GO:0016887",
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/go_to_ncit_mapping_february2020/$translate?code=GO:0016887",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -683,10 +687,14 @@
                 "fhir",
                 "r5",
                 "ConceptMap",
-                "GO_to_NCIt_Mapping_February2020",
+                "go_to_ncit_mapping_february2020",
                 "$translate"
               ],
               "query": [
+                {
+                  "key": "url",
+                  "value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+                },
                 {
                   "key": "code",
                   "value": "GO:0016887"
@@ -714,6 +722,10 @@
               ],
               "query": [
                 {
+                  "key": "system",
+                  "value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+                },
+                {
                   "key": "code",
                   "value": "C19939"
                 },
@@ -732,7 +744,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ConceptMap//GO_to_NCIt_Mapping_February2020/$translate?code=C19939&reverse=true",
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/go_to_ncit_mapping_february2020/$translate?code=C19939&reverse=true",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -740,11 +752,14 @@
                 "fhir",
                 "r5",
                 "ConceptMap",
-                "",
-                "GO_to_NCIt_Mapping_February2020",
+                "go_to_ncit_mapping_february2020",
                 "$translate"
               ],
               "query": [
+                {
+                  "key": "url",
+                  "value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+                },
                 {
                   "key": "code",
                   "value": "C19939"

--- a/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
+++ b/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
@@ -1,0 +1,818 @@
+{
+  "info": {
+    "_postman_id": "9902b889-648c-4881-bd39-3b9942f6ea4f",
+    "name": "EVSRESTAPI FHIR R5",
+    "description": "EVSRESTAPI FHIR Terminology Services API, [https://api-evsrest.nci.nih.gov/fhir/r5/swagger-ui/](https://api-evsrest.nci.nih.gov/fhir/r5/swagger-ui/).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "11076096"
+  },
+  "item": [
+    {
+      "name": "CodeSystem",
+      "item": [
+        {
+          "name": "Get all code systems",
+          "request": {
+            "auth": {
+              "type": "oauth2",
+              "oauth2": [
+                {
+                  "key": "addTokenTo",
+                  "value": "header",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem"
+              ],
+              "query": [
+                {
+                  "key": "_count",
+                  "value": "100",
+                  "disabled": true
+                },
+                {
+                  "key": "_offset",
+                  "value": "0",
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get code systems by id",
+          "request": {
+            "auth": {
+              "type": "oauth2",
+              "oauth2": [
+                {
+                  "key": "addTokenTo",
+                  "value": "header",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/umlssemnet_2023AA",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "umlssemnet_2023AA"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Find code systems by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem?_id=umlssemnet_2023AA",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem"
+              ],
+              "query": [
+                {
+                  "key": "_id",
+                  "value": "umlssemnet_2023AA"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Find code systems by system url",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem?system=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem"
+              ],
+              "query": [
+                {
+                  "key": "system",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Lookup an NCIt code",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$lookup?system=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl&code=C3224",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "$lookup"
+              ],
+              "query": [
+                {
+                  "key": "system",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+                },
+                {
+                  "key": "code",
+                  "value": "C3224"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Lookup a LOINC code",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/lnc_2_68/$lookup?code=10191-5&system=http://loinc.org",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "lnc_2_68",
+                "$lookup"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "10191-5"
+                },
+                {
+                  "key": "system",
+                  "value": "http://loinc.org"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Test for NCIt concept subsumption",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$subsumes?system=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl&codeA=C43431&codeB=C25404",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "$subsumes"
+              ],
+              "query": [
+                {
+                  "key": "system",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+                },
+                {
+                  "key": "version",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "codeA",
+                  "value": "C43431"
+                },
+                {
+                  "key": "codeB",
+                  "value": "C25404"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Validate a SNOMEDCT code",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$validate-code?code=138875005&url=http://terminology.hl7.org/CodeSystem/snomedct_us",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "$validate-code"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "http://terminology.hl7.org/CodeSystem/snomedct_us",
+                  "disabled": true
+                },
+                {
+                  "key": "code",
+                  "value": "138875005"
+                },
+                {
+                  "key": "version",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "url",
+                  "value": "http://terminology.hl7.org/CodeSystem/snomedct_us"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Validate a GO code by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/go_2022-07-01/$validate-code?code=GO:0070966&url=http://purl.obolibrary.org/obo/go.owl",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "go_2022-07-01",
+                "$validate-code"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "GO:0070966"
+                },
+                {
+                  "key": "url",
+                  "value": "http://purl.obolibrary.org/obo/go.owl"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Validate an NCIt Code",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$validate-code?code=C3224&system=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "$validate-code"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "C3224"
+                },
+                {
+                  "key": "system",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Given a code/system, or a Coding, get additional details about the concept, including definition, status, designations, and properties",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "ValueSet",
+      "item": [
+        {
+          "name": "Get all value sets",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet"
+              ],
+              "query": [
+                {
+                  "key": "_count",
+                  "value": "100",
+                  "disabled": true
+                },
+                {
+                  "key": "_offset",
+                  "value": "0",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List all the value sets on the server instance"
+          },
+          "response": []
+        },
+        {
+          "name": "Get value set by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/mdr_23_1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet",
+                "mdr_23_1"
+              ],
+              "query": [
+                {
+                  "key": "",
+                  "value": null,
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "List all the value sets on the server instance"
+          },
+          "response": []
+        },
+        {
+          "name": "Find value set by url",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet?url=https://www.meddra.org",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "https://www.meddra.org"
+                }
+              ]
+            },
+            "description": "List all the value sets on the server instance"
+          },
+          "response": []
+        },
+        {
+          "name": "Validate value set with id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_C54585/$validate-code?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C54585",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet",
+                "ncit_C54585",
+                "$validate-code"
+              ],
+              "query": [
+                {
+                  "key": "system",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C54585",
+                  "disabled": true
+                },
+                {
+                  "key": "code",
+                  "value": "C54585",
+                  "disabled": true
+                },
+                {
+                  "key": "url",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C54585"
+                }
+              ]
+            },
+            "description": "Lists all the reference sets available on the instance of the terminology server"
+          },
+          "response": []
+        },
+        {
+          "name": "Validate code without id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$validate-code?url=https://ncim.nci.nih.gov/ncimbrowser/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet",
+                "$validate-code"
+              ],
+              "query": [
+                {
+                  "key": "system",
+                  "value": "http://snomed.info/sct",
+                  "disabled": true
+                },
+                {
+                  "key": "code",
+                  "value": "80891009",
+                  "disabled": true
+                },
+                {
+                  "key": "url",
+                  "value": "https://ncim.nci.nih.gov/ncimbrowser/"
+                }
+              ]
+            },
+            "description": "Lists all the reference sets available on the instance of the terminology server"
+          },
+          "response": []
+        },
+        {
+          "name": "Expand terminology ValueSet",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$expand?url=https://ncim.nci.nih.gov/ncimbrowser/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet",
+                "$expand"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "https://ncim.nci.nih.gov/ncimbrowser/"
+                }
+              ]
+            },
+            "description": "Lists all the reference sets available on the instance of the terminology server"
+          },
+          "response": []
+        },
+        {
+          "name": "Expand NCIt ValueSet",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$expand?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C159333",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet",
+                "$expand"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C159333"
+                }
+              ]
+            },
+            "description": "Lists all the reference sets available on the instance of the terminology server"
+          },
+          "response": []
+        }
+      ],
+      "description": "The definition of a value set is used to create a simple collection of codes suitable for use for data entry or validation.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "ConceptMap",
+      "item": [
+        {
+          "name": "Get all concept maps",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap"
+              ],
+              "query": [
+                {
+                  "key": "_count",
+                  "value": "100",
+                  "disabled": true
+                },
+                {
+                  "key": "_offset",
+                  "value": "0",
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get concept map by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/GO_to_NCIt_Mapping_February2020",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap",
+                "GO_to_NCIt_Mapping_February2020"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Translate Code no id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/$translate?code=GO:0016887",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap",
+                "$translate"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "GO:0016887"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Translate Code with id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/GO_to_NCIt_Mapping_February2020/$translate?code=GO:0016887",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap",
+                "GO_to_NCIt_Mapping_February2020",
+                "$translate"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "GO:0016887"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Translate Code in reverse",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/$translate?code=C49782&reverse=true",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap",
+                "$translate"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "C49782"
+                },
+                {
+                  "key": "reverse",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Translate Code in reverse with id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap//GO_to_NCIt_Mapping_February2020/$translate?code=C19939&reverse=true",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap",
+                "",
+                "GO_to_NCIt_Mapping_February2020",
+                "$translate"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "C19939"
+                },
+                {
+                  "key": "reverse",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Translate a code from one value set to another, based on the existing value set and concept maps resources, and/or other additional knowledge available to the server",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://api-evsrest.nci.nih.gov"
+    }
+  ]
+}

--- a/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
+++ b/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
@@ -450,7 +450,7 @@
               "query": [
                 {
                   "key": "code",
-                  "value": "C20821"
+                  "value": "c20821"
                 }
               ]
             },
@@ -464,7 +464,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$validate-code?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585&code=C20821",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$validate-code?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585&code=c20821",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -481,7 +481,7 @@
                 },
                 {
                   "key": "code",
-                  "value": "C20821"
+                  "value": "c20821"
                 }
               ]
             },

--- a/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
+++ b/fhir-examples/EVSRESTAPI-FHIR-R5.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "9902b889-648c-4881-bd39-3b9942f6ea4f",
+    "_postman_id": "8d2a2d54-b634-487d-b6f3-27b7a3d9a271",
     "name": "EVSRESTAPI FHIR R5",
     "description": "EVSRESTAPI FHIR Terminology Services API, [https://api-evsrest.nci.nih.gov/fhir/r5/swagger-ui/](https://api-evsrest.nci.nih.gov/fhir/r5/swagger-ui/).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -67,7 +67,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/umlssemnet_2023AA",
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/umlssemnet_2023aa",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -75,7 +75,7 @@
                 "fhir",
                 "r5",
                 "CodeSystem",
-                "umlssemnet_2023AA"
+                "umlssemnet_2023aa"
               ]
             }
           },
@@ -87,7 +87,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/CodeSystem?_id=umlssemnet_2023AA",
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem?_id=umlssemnet_2023aa",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -99,7 +99,7 @@
               "query": [
                 {
                   "key": "_id",
-                  "value": "umlssemnet_2023AA"
+                  "value": "umlssemnet_2023aa"
                 }
               ]
             }
@@ -167,7 +167,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/lnc_2_68/$lookup?code=10191-5&system=http://loinc.org",
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$lookup?system=http://loinc.org&code=10191-5",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -175,17 +175,16 @@
                 "fhir",
                 "r5",
                 "CodeSystem",
-                "lnc_2_68",
                 "$lookup"
               ],
               "query": [
                 {
-                  "key": "code",
-                  "value": "10191-5"
-                },
-                {
                   "key": "system",
                   "value": "http://loinc.org"
+                },
+                {
+                  "key": "code",
+                  "value": "10191-5"
                 }
               ]
             }
@@ -232,83 +231,12 @@
           "response": []
         },
         {
-          "name": "Validate a SNOMEDCT code",
+          "name": "Validate an NCIt code with code system url",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$validate-code?code=138875005&url=http://terminology.hl7.org/CodeSystem/snomedct_us",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "fhir",
-                "r5",
-                "CodeSystem",
-                "$validate-code"
-              ],
-              "query": [
-                {
-                  "key": "url",
-                  "value": "http://terminology.hl7.org/CodeSystem/snomedct_us",
-                  "disabled": true
-                },
-                {
-                  "key": "code",
-                  "value": "138875005"
-                },
-                {
-                  "key": "version",
-                  "value": "",
-                  "disabled": true
-                },
-                {
-                  "key": "url",
-                  "value": "http://terminology.hl7.org/CodeSystem/snomedct_us"
-                }
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Validate a GO code by id",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/go_2022-07-01/$validate-code?code=GO:0070966&url=http://purl.obolibrary.org/obo/go.owl",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "fhir",
-                "r5",
-                "CodeSystem",
-                "go_2022-07-01",
-                "$validate-code"
-              ],
-              "query": [
-                {
-                  "key": "code",
-                  "value": "GO:0070966"
-                },
-                {
-                  "key": "url",
-                  "value": "http://purl.obolibrary.org/obo/go.owl"
-                }
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Validate an NCIt Code",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$validate-code?code=C3224&system=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/$validate-code?code=C3224&url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -324,8 +252,35 @@
                   "value": "C3224"
                 },
                 {
-                  "key": "system",
+                  "key": "url",
                   "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Validate a UMLSSEMNET code with code system id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/CodeSystem/umlssemnet_2023aa/$validate-code?code=T042",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "CodeSystem",
+                "umlssemnet_2023aa",
+                "$validate-code"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "T042"
                 }
               ]
             }
@@ -396,7 +351,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/mdr_23_1",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_C54585",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -404,7 +359,7 @@
                 "fhir",
                 "r5",
                 "ValueSet",
-                "mdr_23_1"
+                "ncit_C54585"
               ],
               "query": [
                 {
@@ -419,12 +374,43 @@
           "response": []
         },
         {
+          "name": "Find value sets by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet?_id=ncit_C54585",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ValueSet"
+              ],
+              "query": [
+                {
+                  "key": "",
+                  "value": null,
+                  "disabled": true
+                },
+                {
+                  "key": "_id",
+                  "value": "ncit_C54585"
+                }
+              ]
+            },
+            "description": "List all the value sets on the server instance"
+          },
+          "response": []
+        },
+        {
           "name": "Find value set by url",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet?url=https://www.meddra.org",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -436,7 +422,7 @@
               "query": [
                 {
                   "key": "url",
-                  "value": "https://www.meddra.org"
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585"
                 }
               ]
             },
@@ -445,12 +431,12 @@
           "response": []
         },
         {
-          "name": "Validate value set with id",
+          "name": "Validate NCIt code with value set id",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_C54585/$validate-code?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C54585",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/ncit_C54585/$validate-code?code=C20821",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -463,18 +449,8 @@
               ],
               "query": [
                 {
-                  "key": "system",
-                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C54585",
-                  "disabled": true
-                },
-                {
                   "key": "code",
-                  "value": "C54585",
-                  "disabled": true
-                },
-                {
-                  "key": "url",
-                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C54585"
+                  "value": "C20821"
                 }
               ]
             },
@@ -483,12 +459,12 @@
           "response": []
         },
         {
-          "name": "Validate code without id",
+          "name": "Validate NCIt code with value set url",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$validate-code?url=https://ncim.nci.nih.gov/ncimbrowser/",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$validate-code?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585&code=C20821",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -500,18 +476,12 @@
               ],
               "query": [
                 {
-                  "key": "system",
-                  "value": "http://snomed.info/sct",
-                  "disabled": true
+                  "key": "url",
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585"
                 },
                 {
                   "key": "code",
-                  "value": "80891009",
-                  "disabled": true
-                },
-                {
-                  "key": "url",
-                  "value": "https://ncim.nci.nih.gov/ncimbrowser/"
+                  "value": "C20821"
                 }
               ]
             },
@@ -520,12 +490,12 @@
           "response": []
         },
         {
-          "name": "Expand terminology ValueSet",
+          "name": "Expand NCIt value set with value set url",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$expand?url=https://ncim.nci.nih.gov/ncimbrowser/",
+              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$expand?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -538,34 +508,7 @@
               "query": [
                 {
                   "key": "url",
-                  "value": "https://ncim.nci.nih.gov/ncimbrowser/"
-                }
-              ]
-            },
-            "description": "Lists all the reference sets available on the instance of the terminology server"
-          },
-          "response": []
-        },
-        {
-          "name": "Expand NCIt ValueSet",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ValueSet/$expand?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C159333",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "fhir",
-                "r5",
-                "ValueSet",
-                "$expand"
-              ],
-              "query": [
-                {
-                  "key": "url",
-                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=$C159333"
+                  "value": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585"
                 }
               ]
             },
@@ -651,7 +594,57 @@
           "response": []
         },
         {
-          "name": "Translate Code no id",
+          "name": "Find concept map by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap?_id=GO_to_NCIt_Mapping_February2020",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap"
+              ],
+              "query": [
+                {
+                  "key": "_id",
+                  "value": "GO_to_NCIt_Mapping_February2020"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Find concept map by url",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap?url=http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "r5",
+                "ConceptMap"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Translate GO code no id",
           "request": {
             "method": "GET",
             "header": [],
@@ -677,7 +670,7 @@
           "response": []
         },
         {
-          "name": "Translate Code with id",
+          "name": "Translate GO code with id",
           "request": {
             "method": "GET",
             "header": [],
@@ -704,12 +697,12 @@
           "response": []
         },
         {
-          "name": "Translate Code in reverse",
+          "name": "Translate GO code in reverse",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/$translate?code=C49782&reverse=true",
+              "raw": "{{baseUrl}}/fhir/r5/ConceptMap/$translate?code=C19939&reverse=true",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -722,7 +715,7 @@
               "query": [
                 {
                   "key": "code",
-                  "value": "C49782"
+                  "value": "C19939"
                 },
                 {
                   "key": "reverse",
@@ -734,7 +727,7 @@
           "response": []
         },
         {
-          "name": "Translate Code in reverse with id",
+          "name": "Translate GO code in reverse with id",
           "request": {
             "method": "GET",
             "header": [],

--- a/fhir-examples/README.md
+++ b/fhir-examples/README.md
@@ -1,11 +1,11 @@
 # EVSRESTAPI: FHIR Tutorial
 
-This tutorial shows how to interact with the FHIR R4 APIs through use of a Postman collection.
+This tutorial shows how to interact with the FHIR APIs through use of a Postman collection.
 
 ## Prerequisites
 
 - Postman must be installed (with a version capable of importing a v2.1 collection)
-- The [EVSRESTAPI-FHIR-R4.postman_collection.json](EVSRESTAPI-FHIR-R4.postman_collection.json) file must be loaded into Postman using File->Iimport to access the R4 FHIR APIs
+- Import the desired file into Postman with `File -> Import`. 
 
 ## Using the Postman Files
 
@@ -23,49 +23,655 @@ FHIR Swagger APIs are also available for these end points.
 Once loaded in, you will see the calls divided into four sections
 
 - [CodeSystem](#codesystem)
+  - [Get all code systems](#get-all-code-systems)
+  - [Get code systems by id](#get-code-systems-by-id)
+  - [Find code systems by id](#find-code-systems-by-id)
+  - [Find code systems by system url](#find-code-systems-by-system-url)
+  - [Lookup an NCIt code](#lookup-an-ncit-code)
+  - [Lookup a LOINC code](#lookup-a-loinc-code)
+  - [Test for NCIt concept subsumption](#test-for-ncit-concept-subsumption)
+  - [Validate a SNOMED CT code](#validate-a-snomed-ct-code)
+  - [Validate a GO code by id](#validate-a-go-code-by-id)
+  - [Validate an NCIt code](#validate-an-ncit-code)
 - [ValueSet](#valueset)
+    - [Get all value sets](#get-all-value-sets)
+    - [Get all value set by id](#get-all-value-set-by-id)
+    - [Find value sets by id](#find-value-sets-by-id)
+    - [Validate values set with id](#validate-values-set-with-id)
+    - [Validate code without id](#validate-code-without-id)
+    - [Expand terminology ValueSet](#expand-terminology-valueset)
+    - [Expand NCIt ValueSet](#expand-ncit-valueset)
 - [ConceptMap](#conceptmap)
+  - [Get all concept maps](#get-all-concept-maps)
+  - [Get concept map by id](#get-concept-map-by-id)
+  - [Translate Code no id](#translate-code-no-id)
+  - [Translate Code with id](#translate-code-with-id)
+  - [Translate Code in reverse](#translate-code-in-reverse)
+  - [Translate Code in reverse with id](#translate-code-in-reverse-with-id)
 - [Server capability statement](#server-capability-statement)
 
-### CodeSystem
+## CodeSystem
+This section holds the api calls for CodeSystem only. The example outputs shown below are for `FHIR R4.` 
 
-## Get all code systems\_
+[Back to Top](#evsrestapi-fhir-tutorial)
 
-Returns a bundle of all code systems for the specified proejct.
+### Get all code systems
 
-## Find code systems by id
+Returns a bundle of all code systems for the specified project.
+
+```json
+{
+    "resourceType": "Bundle",
+    "id": "fca18121-e0b1-4cff-b8ea-2796b606408d",
+    "meta": {
+        "lastUpdated": "2024-09-04T18:08:01.438-04:00"
+    },
+    "type": "searchset",
+    "total": 30,
+    "link": [
+        {
+            "relation": "self",
+            "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem"
+        }
+    ],
+    "entry": [
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/radlex_4_1",
+            "resource": {
+                "resourceType": "CodeSystem",
+                "id": "radlex_4_1",
+                "url": "http://radlex.org/",
+                "version": "4_1",
+                "name": "RadLex: Radiology Lexicon 4_1",
+                "title": "radlex",
+                "status": "active",
+                "experimental": false,
+                "publisher": "RSNA (Radiological Society of North America)",
+                "hierarchyMeaning": "is-a"
+            }
+        },
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/ncit_24.08d",
+            "resource": {
+                "resourceType": "CodeSystem",
+                "id": "ncit_24.08d",
+                "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                "version": "24.08d",
+                "name": "NCI Thesaurus 24.08d",
+                "title": "ncit",
+                "status": "active",
+                "experimental": false,
+                "publisher": "NCI",
+                "hierarchyMeaning": "is-a"
+            }
+        },
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/canmed_202408",
+            "resource": {
+                "resourceType": "CodeSystem",
+                "id": "canmed_202408",
+                "url": "http://seer.nci.nih.gov/CanMED.owl",
+                "version": "202408",
+                "name": "CanMED 202408",
+                "title": "canmed",
+                "status": "active",
+                "experimental": false,
+                "publisher": "National Cancer Institute Enterprise Vocabulary Services",
+                "hierarchyMeaning": "is-a"
+            }
+        },
+      ...
+      ...
+      ...
+    ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Get code systems by id
+
+Returns a bundle containing the code system for a specified `_id` parameter.
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Find code systems by id
 
 Returns a bundle containing the code system for the specified `_id` parameter.
 
-... more info needed here
+```json
+{
+    "resourceType": "Bundle",
+    "id": "a9620763-cb6f-4f4c-9087-17e527f7c01f",
+    "meta": {
+        "lastUpdated": "2024-09-04T18:16:43.411-04:00"
+    },
+    "type": "searchset",
+    "total": 0,
+    "link": [
+        {
+            "relation": "self",
+            "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem?_id=umlssemnet_2023AA"
+        }
+    ]
+}
+```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### ValueSet
+### Find code systems by system url
 
-## Get all value sets
+Returns a bundle contain the code systems for the specified `_url` parameter
 
-Returns a bundle of all value sets for the specified project. EVSRESTAPI always returns value sets in this call that represent all of the codes of the terminology. Thus, there will always be at least one value set for each code system in the project.
+```json
+{
+    "resourceType": "Bundle",
+    "id": "f9369c1d-6572-4599-ae95-a9f509e5a337",
+    "meta": {
+        "lastUpdated": "2024-09-04T18:22:41.145-04:00"
+    },
+    "type": "searchset",
+    "total": 3,
+    "link": [
+        {
+            "relation": "self",
+            "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem?system=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+        }
+    ],
+    "entry": [
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/ncit_24.08d",
+            "resource": {
+                "resourceType": "CodeSystem",
+                "id": "ncit_24.08d",
+                "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                "version": "24.08d",
+                "name": "NCI Thesaurus 24.08d",
+                "title": "ncit",
+                "status": "active",
+                "experimental": false,
+                "publisher": "NCI",
+                "hierarchyMeaning": "is-a"
+            }
+        },
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/ncit_24.07e",
+            "resource": {
+                "resourceType": "CodeSystem",
+                "id": "ncit_24.07e",
+                "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                "version": "24.07e",
+                "name": "NCI Thesaurus 24.07e",
+                "title": "ncit",
+                "status": "active",
+                "experimental": false,
+                "publisher": "NCI",
+                "hierarchyMeaning": "is-a"
+            }
+        },
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/ncit_24.06d",
+            "resource": {
+                "resourceType": "CodeSystem",
+                "id": "ncit_24.06d",
+                "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                "version": "24.06d",
+                "name": "NCI Thesaurus 24.06d",
+                "title": "ncit",
+                "status": "active",
+                "experimental": false,
+                "publisher": "NCI",
+                "hierarchyMeaning": "is-a"
+            }
+        }
+    ]
+}
+```
+[Back to Top](#evsrestapi-fhir-tutorial)
 
-## Find value sets by id
+### Lookup an NCIt code
+
+Returns a Parameters of all the code systems for a `_system_url` and NCIt `_code`
+
+```json
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "code",
+            "valueString": "code"
+        },
+        {
+            "name": "system",
+            "valueString": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+        },
+        {
+            "name": "code",
+            "valueString": "NCI Thesaurus 24.08d"
+        },
+        {
+            "name": "version",
+            "valueString": "24.08d"
+        },
+        {
+            "name": "display",
+            "valueString": "Melanoma"
+        },
+        {
+            "name": "active",
+            "valueBoolean": true
+        },
+        {
+            "name": "property",
+            "part": [
+                {
+                    "name": "code",
+                    "valueCode": "child"
+                },
+                {
+                    "name": "value",
+                    "valueCode": "C3802"
+                }
+            ]
+        },
+        {
+            "name": "property",
+            "part": [
+                {
+                    "name": "code",
+                    "valueCode": "child"
+                },
+                {
+                    "name": "value",
+                    "valueCode": "C8410"
+                }
+            ]
+        },
+        {
+            "name": "property",
+            "part": [
+                {
+                    "name": "code",
+                    "valueCode": "child"
+                },
+                {
+                    "name": "value",
+                    "valueCode": "C131506"
+                }
+            ]
+        },
+      ...
+      ...
+      ...
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Lookup a LOINC code
+
+Returns a Parameters of all the code systems for a `_system_url` and LOINC `_code`
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Test for NCIt concept subsumption
+
+Returns a Parameters of all the code systems for a `_system_url` and NCIt `_code`
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "system",
+      "valueString": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+    },
+    {
+      "name": "version",
+      "valueString": "24.08d"
+    },
+    {
+      "name": "outcome",
+      "valueString": "subsumed-by"
+    }
+  ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Validate a SNOMED CT code
+
+Returns a Parameters of all the code systems for a `_system_url` and SNOMED CT `_code`
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "result",
+      "valueBoolean": true
+    },
+    {
+      "name": "code",
+      "valueString": "138875005"
+    },
+    {
+      "name": "url",
+      "valueString": "http://terminology.hl7.org/CodeSystem/snomedct_us"
+    },
+    {
+      "name": "version",
+      "valueString": "2024_03_01"
+    },
+    {
+      "name": "display",
+      "valueString": "SNOMED CT Concept"
+    },
+    {
+      "name": "active",
+      "valueBoolean": true
+    }
+  ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Validate a GO code by id
+
+Returns a Parameters for all code systems for a `_system_url` and GO `_code`
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Validate an NCIt code
+
+Returns a Parameters for all code systems for a `_system_url` and NCIt `_code`
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+## ValueSet
+
+This section holds the api calls for ValueSet only. The example outputs shown below are for `FHIR R5`.
+
+
+### Get all value sets
+
+Returns a bundle of all value sets for the specified project. EVSRESTAPI always returns value sets in this call that
+represent all the codes of the terminology. Thus, there will always be at least one value set for each code system in
+the project.
+
+### Get all value set by id
+
+Returns a bundles of all velue sets for a specified `_id` parameter.
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Find value sets by id
 
 Returns a bundle containing the value set for the specified `_id` parameter.
 
-... more info needed here
+```json
+TBD
+```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### ConceptMap
+### Validate values set with id
 
-## Get all concept maps
+Returns a Parameters for all value sets for a specified `_url` parameter.
 
-We are working on implementing concept maps and currently there are none loaded for testing.
-
-... more info needed here
+```json
+TBD
+```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Server capability statement
+### Validate code without id
+
+Returns a Parameters for all value sets for a specified `_url` parameter.
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Expand terminology ValueSet
+
+Returns a ValueSet for all value sets for a specified `_url` parameter.
+
+```json
+
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Expand NCIt ValueSet
+
+Returns a ValueSet for all value sets for a specified `_url` parameter.
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+
+## ConceptMap
+
+This section holds the api calls for ConceptMap only. The example outputs shown below are for `FHIR R4`.
+
+
+### Get all concept maps
+
+Returns a Bundle of all concept maps for the specified project.
+
+```json
+{
+  "resourceType": "Bundle",
+  "id": "cb83ea23-e3e5-477f-bf4a-44c666bcce8d",
+  "meta": {
+    "lastUpdated": "2024-09-04T18:50:10.632-04:00"
+  },
+  "type": "searchset",
+  "total": 8,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap/GO_to_NCIt_Mapping_February2020",
+      "resource": {
+        "resourceType": "ConceptMap",
+        "id": "GO_to_NCIt_Mapping_February2020",
+        "url": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping",
+        "version": "February2020",
+        "name": "GO_to_NCIt_Mapping",
+        "title": "GO_to_NCIt_Mapping",
+        "status": "active",
+        "experimental": false,
+        "publisher": "GO Consortium",
+        "group": [
+          {
+            "source": "http://purl.obolibrary.org/obo/go.owl",
+            "sourceVersion": "February2020",
+            "target": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+            "targetVersion": "20.02d"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap/ICD10_to_MedDRA_Mapping_July2023",
+      "resource": {
+        "resourceType": "ConceptMap",
+        "id": "ICD10_to_MedDRA_Mapping_July2023",
+        "url": "http://hl7.org/fhir/sid/icd-10?fhir_cm=ICD10_to_MedDRA_Mapping",
+        "version": "July2023",
+        "name": "ICD10_to_MedDRA_Mapping",
+        "title": "ICD10_to_MedDRA_Mapping",
+        "status": "active",
+        "experimental": false,
+        "publisher": "World Health Organization",
+        "group": [
+          {
+            "source": "http://hl7.org/fhir/sid/icd-10",
+            "sourceVersion": "2019",
+            "target": "https://www.meddra.org",
+            "targetVersion": "23.1"
+          }
+        ]
+      }
+    },
+    {
+      ...
+      ...
+    }
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Get concept map by id
+
+Returns a ConceptMap for the specified `_id` parameter.
+
+```json
+{
+    "resourceType": "ConceptMap",
+    "id": "GO_to_NCIt_Mapping_February2020",
+    "url": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping",
+    "version": "February2020",
+    "name": "GO_to_NCIt_Mapping",
+    "title": "GO_to_NCIt_Mapping",
+    "status": "active",
+    "experimental": false,
+    "publisher": "GO Consortium",
+    "group": [
+        {
+            "source": "http://purl.obolibrary.org/obo/go.owl",
+            "sourceVersion": "February2020",
+            "target": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+            "targetVersion": "20.02d"
+        }
+    ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Translate Code no id
+
+Returns a Parameters for all concept maps for a specified `_code` parameter.
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Translate Code with id
+
+Returns a Parameters for all concept maps for a specified `_id` and `_code` parameter.
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "result",
+      "valueBoolean": true
+    },
+    {
+      "name": "match",
+      "part": [
+        {
+          "name": "equivalence",
+          "valueString": "equivalent"
+        },
+        {
+          "name": "concept",
+          "valueCoding": {
+            "system": "NCI_Thesaurus",
+            "code": "C19939",
+            "display": "ATP Hydrolysis"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Translate Code in reverse
+
+Returns a Parameters for all concept maps for a specified `_code` and `_reverse` parameter.
+
+```json
+TBD
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Translate Code in reverse with id
+
+Returns a Parameters for all concept maps for a specified `_id`, `_code`, and `_reverse` parameter.
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "result",
+      "valueBoolean": true
+    },
+    {
+      "name": "match",
+      "part": [
+        {
+          "name": "equivalence",
+          "valueString": "equivalent"
+        },
+        {
+          "name": "concept",
+          "valueCoding": {
+            "code": "GO:0016887",
+            "display": "ATP hydrolysis activity"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+## Server capability statement
 
 This is just the FHIR metadata call that describes the capabilities of the server deployment.
 

--- a/fhir-examples/README.md
+++ b/fhir-examples/README.md
@@ -1,6 +1,7 @@
 # EVSRESTAPI: FHIR Tutorial
 
-This tutorial shows how to interact with the FHIR APIs through use of a Postman collection.
+This tutorial shows how to interact with the FHIR APIs through use of a Postman collection. All outputs were generated
+with the R4 version of the file. 
 
 ## Prerequisites
 
@@ -30,25 +31,26 @@ Once loaded in, you will see the calls divided into four sections
   - [Lookup an NCIt code](#lookup-an-ncit-code)
   - [Lookup a LOINC code](#lookup-a-loinc-code)
   - [Test for NCIt concept subsumption](#test-for-ncit-concept-subsumption)
-  - [Validate a SNOMED CT code](#validate-a-snomed-ct-code)
-  - [Validate a GO code by id](#validate-a-go-code-by-id)
-  - [Validate an NCIt code](#validate-an-ncit-code)
+  - [Validate an NCIt code with code system url](#validate-an-ncit-code-with-code-system-url)
+  - [Validate a ULMSSEMNET code with code system url](#validate-a-ulmssemnet-code-with-code-system-url)
 - [ValueSet](#valueset)
     - [Get all value sets](#get-all-value-sets)
     - [Get all value set by id](#get-all-value-set-by-id)
     - [Find value sets by id](#find-value-sets-by-id)
-    - [Validate values set with id](#validate-values-set-with-id)
-    - [Validate code without id](#validate-code-without-id)
-    - [Expand terminology ValueSet](#expand-terminology-valueset)
-    - [Expand NCIt ValueSet](#expand-ncit-valueset)
+    - [Find value set by url](#find-value-set-by-url)
+    - [Validate NCIt code with value set id](#validate-ncit-code-with-value-set-id)
+    - [Validate NCIt code value set url](#validate-ncit-code-with-value-set-url)
+    - [Expand NCIt value set with value set url](#expand-ncit-value-set-with-value-set-url)
+
 - [ConceptMap](#conceptmap)
   - [Get all concept maps](#get-all-concept-maps)
   - [Get concept map by id](#get-concept-map-by-id)
-  - [Translate Code no id](#translate-code-no-id)
-  - [Translate Code with id](#translate-code-with-id)
-  - [Translate Code in reverse](#translate-code-in-reverse)
-  - [Translate Code in reverse with id](#translate-code-in-reverse-with-id)
-- [Server capability statement](#server-capability-statement)
+  - [Find concept maps by id](#find-concept-maps-by-id)
+  - [Find concept maps by url](#find-concept-maps-by-url)
+  - [Translate GO code no id](#translate-go-code-no-id)
+  - [Translate GO code with id](#translate-go-code-with-id)
+  - [Translate GO code in reverse](#translate-go-code-in-reverse)
+  - [Translate GO code in reverse with id](#translate-go-code-in-reverse-with-id)
 
 ## CodeSystem
 This section holds the api calls for CodeSystem only. The example outputs shown below are for `FHIR R4.` 
@@ -57,7 +59,7 @@ This section holds the api calls for CodeSystem only. The example outputs shown 
 
 ### Get all code systems
 
-Returns a bundle of all code systems for the specified project.
+Returns a Bundle of all code systems for the specified project.
 
 ```json
 {
@@ -131,33 +133,61 @@ Returns a bundle of all code systems for the specified project.
 
 ### Get code systems by id
 
-Returns a bundle containing the code system for a specified `_id` parameter.
+Returns a code system for a specified `_id` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "CodeSystem",
+  "id": "umlssemnet_2023aa",
+  "url": "http://www.nlm.nih.gov/research/umls/umlssemnet.owl",
+  "version": "2023aa",
+  "name": "UMLS Semantic Network 2023aa",
+  "title": "umlssemnet",
+  "status": "active",
+  "experimental": false,
+  "publisher": "National Library of Medicine",
+  "hierarchyMeaning": "is-a"
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
 ### Find code systems by id
 
-Returns a bundle containing the code system for the specified `_id` parameter.
+Returns a Bundle containing the code system for the specified `_id` parameter.
 
 ```json
 {
-    "resourceType": "Bundle",
-    "id": "a9620763-cb6f-4f4c-9087-17e527f7c01f",
-    "meta": {
-        "lastUpdated": "2024-09-04T18:16:43.411-04:00"
-    },
-    "type": "searchset",
-    "total": 0,
-    "link": [
-        {
-            "relation": "self",
-            "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem?_id=umlssemnet_2023AA"
-        }
-    ]
+  "resourceType": "Bundle",
+  "id": "d8c3f2f5-e70f-4eed-a89c-e16f9eeb9175",
+  "meta": {
+    "lastUpdated": "2024-09-05T15:37:19.067-04:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem?_id=umlssemnet_2023aa"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/CodeSystem/umlssemnet_2023aa",
+      "resource": {
+        "resourceType": "CodeSystem",
+        "id": "umlssemnet_2023aa",
+        "url": "http://www.nlm.nih.gov/research/umls/umlssemnet.owl",
+        "version": "2023aa",
+        "name": "UMLS Semantic Network 2023aa",
+        "title": "umlssemnet",
+        "status": "active",
+        "experimental": false,
+        "publisher": "National Library of Medicine",
+        "hierarchyMeaning": "is-a"
+      }
+    }
+  ]
 }
 ```
 
@@ -165,7 +195,7 @@ Returns a bundle containing the code system for the specified `_id` parameter.
 
 ### Find code systems by system url
 
-Returns a bundle contain the code systems for the specified `_url` parameter
+Returns a Bundle contain the code systems for the specified `_url` parameter
 
 ```json
 {
@@ -316,7 +346,35 @@ Returns a Parameters of all the code systems for a `_system_url` and NCIt `_code
 Returns a Parameters of all the code systems for a `_system_url` and LOINC `_code`
 
 ```json
-TBD
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "code",
+      "valueString": "code"
+    },
+    {
+      "name": "system",
+      "valueString": "http://loinc.org"
+    },
+    {
+      "name": "code",
+      "valueString": "LOINC: Logical Observation Identifier Names and Codes 2_77"
+    },
+    {
+      "name": "version",
+      "valueString": "2_77"
+    },
+    {
+      "name": "display",
+      "valueString": "Physical findings:Find:Pt:Abdomen:Nar:Observed"
+    },
+    {
+      "name": "active",
+      "valueBoolean": true
+    }
+  ]
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
@@ -347,7 +405,7 @@ Returns a Parameters of all the code systems for a `_system_url` and NCIt `_code
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Validate a SNOMED CT code
+### Validate an NCIt code with code system url
 
 Returns a Parameters of all the code systems for a `_system_url` and SNOMED CT `_code`
 
@@ -361,19 +419,19 @@ Returns a Parameters of all the code systems for a `_system_url` and SNOMED CT `
     },
     {
       "name": "code",
-      "valueString": "138875005"
+      "valueString": "C3224"
     },
     {
       "name": "url",
-      "valueString": "http://terminology.hl7.org/CodeSystem/snomedct_us"
+      "valueString": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
     },
     {
       "name": "version",
-      "valueString": "2024_03_01"
+      "valueString": "24.08d"
     },
     {
       "name": "display",
-      "valueString": "SNOMED CT Concept"
+      "valueString": "Melanoma"
     },
     {
       "name": "active",
@@ -385,93 +443,367 @@ Returns a Parameters of all the code systems for a `_system_url` and SNOMED CT `
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Validate a GO code by id
+### Validate a ULMSSEMNET code with code system url
 
 Returns a Parameters for all code systems for a `_system_url` and GO `_code`
 
 ```json
-TBD
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "result",
+      "valueBoolean": true
+    },
+    {
+      "name": "code",
+      "valueString": "T042"
+    },
+    {
+      "name": "url",
+      "valueString": "http://www.nlm.nih.gov/research/umls/umlssemnet.owl"
+    },
+    {
+      "name": "version",
+      "valueString": "2023aa"
+    },
+    {
+      "name": "display",
+      "valueString": "Organ or Tissue Function"
+    },
+    {
+      "name": "active",
+      "valueBoolean": true
+    }
+  ]
+}
 ```
-
-[Back to Top](#evsrestapi-fhir-tutorial)
-
-### Validate an NCIt code
-
-Returns a Parameters for all code systems for a `_system_url` and NCIt `_code`
-
-```json
-TBD
-```
-
-[Back to Top](#evsrestapi-fhir-tutorial)
 
 ## ValueSet
 
-This section holds the api calls for ValueSet only. The example outputs shown below are for `FHIR R5`.
+This section holds the api calls for ValueSet only. The example outputs shown below are for `FHIR R4`.
 
 
 ### Get all value sets
 
-Returns a bundle of all value sets for the specified project. EVSRESTAPI always returns value sets in this call that
+Returns a Bundle of all value sets for the specified project. EVSRESTAPI always returns value sets in this call that
 represent all the codes of the terminology. Thus, there will always be at least one value set for each code system in
 the project.
 
+```json
+{
+    "resourceType": "Bundle",
+    "id": "051463e7-1f14-44d9-8629-d1d07b99c6dc",
+    "meta": {
+        "lastUpdated": "2024-09-05T15:43:50.225-04:00"
+    },
+    "type": "searchset",
+    "total": 2067,
+    "link": [
+        {
+            "relation": "self",
+            "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet"
+        },
+        {
+            "relation": "next",
+            "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet?_offset=100&_count=100"
+        }
+    ],
+    "entry": [
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet/radlex_4_1",
+            "resource": {
+                "resourceType": "ValueSet",
+                "id": "radlex_4_1",
+                "url": "http://radlex.org/",
+                "version": "4_1",
+                "name": "RadLex: Radiology Lexicon 4_1",
+                "title": "radlex",
+                "status": "active",
+                "experimental": false,
+                "publisher": "RSNA (Radiological Society of North America)",
+                "description": ";;Radiological Society of North America;;RadLex 4.1;;;;;;;March 20, 2018;Oak Brook, IL;;;RadLex 4.1"
+            }
+        },
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet/ncit_24.08d",
+            "resource": {
+                "resourceType": "ValueSet",
+                "id": "ncit_24.08d",
+                "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                "version": "24.08d",
+                "name": "NCI Thesaurus 24.08d",
+                "title": "ncit",
+                "status": "active",
+                "experimental": false,
+                "publisher": "NCI",
+                "description": "NCI Thesaurus, a controlled vocabulary in support of NCI administrative and scientific activities. Produced by the Enterprise Vocabulary System (EVS), a project by the NCI Center for Biomedical Informatics and Information Technology. National Cancer Institute, National Institutes of Health, Bethesda, MD 20892, U.S.A."
+            }
+        },
+        {
+            "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet/canmed_202408",
+            "resource": {
+                "resourceType": "ValueSet",
+                "id": "canmed_202408",
+                "url": "http://seer.nci.nih.gov/CanMED.owl",
+                "version": "202408",
+                "name": "CanMED 202408",
+                "title": "canmed",
+                "status": "active",
+                "experimental": false,
+                "publisher": "National Cancer Institute Enterprise Vocabulary Services",
+                "description": "Cancer Medications Enquiry Database (CanMED)"
+            }
+        },
+        ...
+        ...
+        ...
+        }
+    ]
+}
+```
+
 ### Get all value set by id
 
-Returns a bundles of all velue sets for a specified `_id` parameter.
+Returns a Value Set for a specified `_id` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "ValueSet",
+  "id": "ncit_C54585",
+  "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+  "identifier": [
+    {
+      "value": "C54585"
+    }
+  ],
+  "version": "24.08d",
+  "name": "Occupation ICSR Terminology",
+  "title": "ncit",
+  "status": "active",
+  "experimental": false,
+  "publisher": "NCI",
+  "description": "Value set representing the ncit subset C54585"
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
 ### Find value sets by id
 
-Returns a bundle containing the value set for the specified `_id` parameter.
+Returns a Bundle containing the value set for the specified `_id` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "Bundle",
+  "id": "b5aeb115-c384-424c-b054-19c0745e5046",
+  "meta": {
+    "lastUpdated": "2024-09-05T15:45:43.349-04:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet?_id=ncit_C54585"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet/ncit_C54585",
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "ncit_C54585",
+        "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "identifier": [
+          {
+            "value": "C54585"
+          }
+        ],
+        "version": "24.08d",
+        "name": "Occupation ICSR Terminology",
+        "title": "ncit",
+        "status": "active",
+        "experimental": false,
+        "publisher": "NCI",
+        "description": "Value set representing the ncit subset C54585"
+      }
+    }
+  ]
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Validate values set with id
+### Find value set by url
 
-Returns a Parameters for all value sets for a specified `_url` parameter.
+Returns a Bundle for all value sets for a specified `_url` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "Bundle",
+  "id": "95e2dd50-a816-4dd2-97d4-e050acab83f0",
+  "meta": {
+    "lastUpdated": "2024-09-05T15:46:00.412-04:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet?url=http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ValueSet/ncit_C54585",
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "ncit_C54585",
+        "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "identifier": [
+          {
+            "value": "C54585"
+          }
+        ],
+        "version": "24.08d",
+        "name": "Occupation ICSR Terminology",
+        "title": "ncit",
+        "status": "active",
+        "experimental": false,
+        "publisher": "NCI",
+        "description": "Value set representing the ncit subset C54585"
+      }
+    }
+  ]
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Validate code without id
+### Validate NCIt code with value set id
 
-Returns a Parameters for all value sets for a specified `_url` parameter.
+Returns a Parameters for a specified value set `_id` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "result",
+      "valueBoolean": true
+    },
+    {
+      "name": "display",
+      "valueString": "Nurse"
+    }
+  ]
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Expand terminology ValueSet
+### Validate NCIt code with value set url
 
-Returns a ValueSet for all value sets for a specified `_url` parameter.
+Returns a Parameters for a specified value set `_url` parameter.
 
 ```json
-
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "result",
+            "valueBoolean": true
+        },
+        {
+            "name": "display",
+            "valueString": "Nurse"
+        }
+    ]
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Expand NCIt ValueSet
+### Expand NCIt value set with value set url
 
-Returns a ValueSet for all value sets for a specified `_url` parameter.
+Returns a Value Set for all value sets for a specified `_url` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "ValueSet",
+  "id": "ncit_C54585",
+  "url": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+  "identifier": [
+    {
+      "value": "C54585"
+    }
+  ],
+  "version": "24.08d",
+  "name": "Occupation ICSR Terminology",
+  "title": "ncit",
+  "status": "active",
+  "experimental": false,
+  "publisher": "NCI",
+  "description": "Value set representing the ncit subset C54585",
+  "expansion": {
+    "timestamp": "2024-09-05T15:47:46-04:00",
+    "total": 10,
+    "offset": 0,
+    "contains": [
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C1000",
+        "display": "Recombinant Amphiregulin"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C10000",
+        "display": "Cyclophosphamide/Fluoxymesterone/Mitolactol/Prednisone/Tamoxifen"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100000",
+        "display": "Percutaneous Coronary Intervention for ST Elevation Myocardial Infarction-Stable-Over 12 Hours From Symptom Onset"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100001",
+        "display": "Percutaneous Coronary Intervention for ST Elevation Myocardial Infarction-Stable After Successful Full-Dose Thrombolytic Therapy"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100002",
+        "display": "Percutaneous Coronary Intervention for ST Elevation Myocardial Infarction-Unstable-Over 12 Hours From Symptom Onset"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100003",
+        "display": "Percutaneous Mitral Valve Repair"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100004",
+        "display": "Pericardial Stripping"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100005",
+        "display": "Post-Cardiac Transplant Evaluation"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100006",
+        "display": "Pre-Operative Evaluation for Non-Cardiovascular Surgery"
+      },
+      {
+        "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl?fhir_vs=C54585",
+        "code": "C100007",
+        "display": "Previously Implanted Cardiac Lead"
+      }
+    ]
+  }
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
@@ -480,7 +812,6 @@ TBD
 ## ConceptMap
 
 This section holds the api calls for ConceptMap only. The example outputs shown below are for `FHIR R4`.
-
 
 ### Get all concept maps
 
@@ -556,7 +887,7 @@ Returns a Bundle of all concept maps for the specified project.
 
 ### Get concept map by id
 
-Returns a ConceptMap for the specified `_id` parameter.
+Returns a Concept Map for the specified `_id` parameter.
 
 ```json
 {
@@ -582,19 +913,128 @@ Returns a ConceptMap for the specified `_id` parameter.
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Translate Code no id
+### Find concept maps by id
 
-Returns a Parameters for all concept maps for a specified `_code` parameter.
+Returns a Bundle for a specified concept map `_code` parameter.
 
 ```json
-TBD
+{
+  "resourceType": "Bundle",
+  "id": "e97ec651-f6a0-47ff-8cdc-66c876e20ac5",
+  "meta": {
+    "lastUpdated": "2024-09-05T15:54:21.526-04:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap?_id=GO_to_NCIt_Mapping_February2020"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap/GO_to_NCIt_Mapping_February2020",
+      "resource": {
+        "resourceType": "ConceptMap",
+        "id": "GO_to_NCIt_Mapping_February2020",
+        "url": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping",
+        "version": "February2020",
+        "name": "GO_to_NCIt_Mapping",
+        "title": "GO_to_NCIt_Mapping",
+        "status": "active",
+        "experimental": false,
+        "publisher": "GO Consortium",
+        "group": [
+          {
+            "source": "http://purl.obolibrary.org/obo/go.owl",
+            "sourceVersion": "February2020",
+            "target": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+            "targetVersion": "20.02d"
+          }
+        ]
+      }
+    }
+  ]
+}
 ```
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Translate Code with id
+### Find concept maps by url
 
-Returns a Parameters for all concept maps for a specified `_id` and `_code` parameter.
+Returns a Bundle for a specified concept map `_url` parameter.
+
+```json
+{
+  "resourceType": "Bundle",
+  "id": "0513296b-5b32-4f92-bfcd-5414845a6014",
+  "meta": {
+    "lastUpdated": "2024-09-05T15:55:07.423-04:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap?url=http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "http://ncias-p2325-c.nci.nih.gov:8080/fhir/r4/ConceptMap/GO_to_NCIt_Mapping_February2020",
+      "resource": {
+        "resourceType": "ConceptMap",
+        "id": "GO_to_NCIt_Mapping_February2020",
+        "url": "http://purl.obolibrary.org/obo/go.owl?fhir_cm=GO_to_NCIt_Mapping",
+        "version": "February2020",
+        "name": "GO_to_NCIt_Mapping",
+        "title": "GO_to_NCIt_Mapping",
+        "status": "active",
+        "experimental": false,
+        "publisher": "GO Consortium",
+        "group": [
+          {
+            "source": "http://purl.obolibrary.org/obo/go.owl",
+            "sourceVersion": "February2020",
+            "target": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+            "targetVersion": "20.02d"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+
+### Translate GO code no id
+
+Returns a Parameters for a specified GO code but no `_id` parameter.
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "result",
+      "valueBoolean": false
+    },
+    {
+      "name": "match",
+      "valueString": "none"
+    }
+  ]
+}
+```
+
+[Back to Top](#evsrestapi-fhir-tutorial)
+
+### Translate GO code with id
+
+Returns a Parameters for a specified concept map `_id` and GO `_code`  parameter.
 
 ```json
 {
@@ -627,19 +1067,9 @@ Returns a Parameters for all concept maps for a specified `_id` and `_code` para
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-### Translate Code in reverse
+### Translate GO code in reverse
 
-Returns a Parameters for all concept maps for a specified `_code` and `_reverse` parameter.
-
-```json
-TBD
-```
-
-[Back to Top](#evsrestapi-fhir-tutorial)
-
-### Translate Code in reverse with id
-
-Returns a Parameters for all concept maps for a specified `_id`, `_code`, and `_reverse` parameter.
+Returns a Parameters for a specified `_code`, and `_reverse=true` parameter.
 
 ```json
 {
@@ -647,23 +1077,11 @@ Returns a Parameters for all concept maps for a specified `_id`, `_code`, and `_
   "parameter": [
     {
       "name": "result",
-      "valueBoolean": true
+      "valueBoolean": false
     },
     {
       "name": "match",
-      "part": [
-        {
-          "name": "equivalence",
-          "valueString": "equivalent"
-        },
-        {
-          "name": "concept",
-          "valueCoding": {
-            "code": "GO:0016887",
-            "display": "ATP hydrolysis activity"
-          }
-        }
-      ]
+      "valueString": "none"
     }
   ]
 }
@@ -671,8 +1089,36 @@ Returns a Parameters for all concept maps for a specified `_id`, `_code`, and `_
 
 [Back to Top](#evsrestapi-fhir-tutorial)
 
-## Server capability statement
+### Translate GO code in reverse with id
 
-This is just the FHIR metadata call that describes the capabilities of the server deployment.
+Returns a Parameters for a specified concept map `_id`, `_code`, and `_reverse=true` parameter.
+
+```json
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "result",
+            "valueBoolean": true
+        },
+        {
+            "name": "match",
+            "part": [
+                {
+                    "name": "equivalence",
+                    "valueString": "equivalent"
+                },
+                {
+                    "name": "concept",
+                    "valueCoding": {
+                        "code": "GO:0016887",
+                        "display": "ATP hydrolysis activity"
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
 
 [Back to Top](#evsrestapi-fhir-tutorial)


### PR DESCRIPTION
Updated the R4 and R5 examples to use lower case where needed. Updated the README to include example outputs using R4/R5 outputs from postman. 

During testing with CodeSystem and ValueSet, lowercase code values didn't return results. All values have been updated to use lowercase or uppercase based on what results were returned. 

In R4, Translate calls without an id are not getting a matches. I'm not sure why this is happening since all of the tests are passing in evsrestapi. Need a second pair of eyes to investigate as this may just be my data.