### PR TITLE
Ams/evsrestapi client sdk fixing curl examples

### DIFF
--- a/curl-examples/README.md
+++ b/curl-examples/README.md
@@ -210,8 +210,8 @@ The fourth call returns summary information for the three listed properties (by 
 ```
 curl "$API_URL/metadata/ncit/properties" | jq '.'
 curl "$API_URL/metadata/ncit/properties?include=summary" | jq '.'
-curl "$API_URL/metadata/ncit/properties?list=P201,P203,P205&include=summary" | jq '.'
-curl "$API_URL/metadata/ncit/properties?list=OLD_CHILD,OLD_KIND,OLD_STATE&include=summary" | jq '.'
+curl "$API_URL/metadata/ncit/properties?list=P201,P203,P204&include=summary" | jq '.'
+curl "$API_URL/metadata/ncit/properties?list=OLD_CHILD,OLD_KIND,OLD_ROLE&include=summary" | jq '.'
 ```
 
 See sample payload data from this call in [`samples/get-properties.txt`](samples/get-properties.txt)
@@ -242,7 +242,7 @@ The fourth call returns summary information for the three listed qualifiers (by 
 curl "$API_URL/metadata/ncit/qualifiers" | jq '.'
 curl "$API_URL/metadata/ncit/qualifiers?include=summary" | jq '.'
 curl "$API_URL/metadata/ncit/qualifiers?list=P387,P381&include=summary" | jq '.'
-curl "$API_URL/metadata/ncit/qualifiers?list=def-source,attr&include=summary" | jq '.'
+curl "$API_URL/metadata/ncit/qualifiers?list=go-id,attribution&include=summary" | jq '.'
 ```
 
 See sample payload data from this call in [`samples/get-qualifiers.txt`](samples/get-qualifiers.txt)

--- a/curl-examples/README.md
+++ b/curl-examples/README.md
@@ -329,8 +329,8 @@ See sample payload data from this call in [`samples/get-associations.txt`](sampl
 Return association for the specified code or label.
 
 ```
-curl "$API_URL/metadata/ncit/association/A10?include=summary" | jq '.'
-curl "$API_URL/metadata/ncit/association/Has_CDRH_Parent?include=summary" | jq '.'
+curl "$API_URL/metadata/ncit/association/A16?include=summary" | jq '.'
+curl "$API_URL/metadata/ncit/association/Has_INC_Parent?include=summary" | jq '.'
 ```
 
 See sample payload data from this call in [`samples/get-association.txt`](samples/get-association.txt)

--- a/curl-examples/samples/get-association.txt
+++ b/curl-examples/samples/get-association.txt
@@ -1,40 +1,26 @@
 {
-  "code": "A10",
-  "name": "Has_CDRH_Parent",
+  "code": "A16",
+  "name": "Has_INC_Parent",
   "terminology": "ncit",
-  "version": "21.11e",
+  "version": "25.01d",
   "synonyms": [
     {
-      "name": "Has CDRH Parent",
-      "type": "Display_Name"
+      "name": "Has_INC_Parent",
+      "type": "FULL_SYN"
     },
     {
-      "name": "Has_CDRH_Parent",
-      "termGroup": "PT",
-      "type": "FULL_SYN",
-      "source": "NCI"
-    },
-    {
-      "name": "Has_CDRH_Parent",
+      "name": "Has_INC_Parent",
       "type": "Preferred_Name"
     }
   ],
   "definitions": [
     {
-      "definition": "An association created to allow the source CDRH to assign a parent to each concept with the intent of creating a hierarchy that includes only terms in which they are the contributing source.",
-      "type": "DEFINITION",
-      "source": "NCI"
+      "definition": "An association created to allow the source INC to assign a parent to each concept with the intent of creating a hierarchy that includes only terms 
+in which they are the contributing source.",
+      "type": "DEFINITION"
     }
   ],
   "properties": [
-    {
-      "type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-      "value": "http://www.w3.org/2002/07/owl#AnnotationProperty"
-    },
-    {
-      "type": "http://www.w3.org/2000/01/rdf-schema#range",
-      "value": "http://www.w3.org/2001/XMLSchema#anyURI"
-    },
     {
       "type": "Semantic_Type",
       "value": "Conceptual Entity"


### PR DESCRIPTION
Fixed several examples in the Curl examples:

- Get association by code or label used retired association A10; changed to A16, which seems to be an association in the same ballpark
- Get all qualifiers call by listed qualifier labels had labels which didn't work; changed to working labels
- Get all properties call by listed code or label had a retired/non-working code P205; changed to P204, which works and seems somewhat similar