### PR TITLE
Fixed instances of a10, replaced with A16

### DIFF
--- a/bash-examples/get-association.sh
+++ b/bash-examples/get-association.sh
@@ -10,8 +10,8 @@ esac; shift; done
 if [ ${#arr[@]} -ne 1 ] && [ ${#arr[@]} -ne 2 ]; then
   echo "Usage: $0 <terminology> [<associationCodeOrLabel>[,<associationCodeOrLabel>]] [--include <include>]"
   echo "  e.g. $0 ncit"
-  echo "  e.g. $0 ncit A10"
-  echo "  e.g. $0 ncit A10 --include summary"
+  echo "  e.g. $0 ncit A16"
+  echo "  e.g. $0 ncit A16 --include summary"
   echo "  e.g. $0 ncit Role_Has_Domain --include synonyms"
   echo "  e.g. $0 ncit A1,A2,A3 --include summary"
   exit 1

--- a/postman-examples/EVSRESTAPI-Postman-Client.json
+++ b/postman-examples/EVSRESTAPI-Postman-Client.json
@@ -375,7 +375,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{API_URL}}/metadata/ncit/association/A10?include=summary",
+					"raw": "{{API_URL}}/metadata/ncit/association/A16?include=summary",
 					"host": [
 						"{{API_URL}}"
 					],
@@ -383,7 +383,7 @@
 						"metadata",
 						"ncit",
 						"association",
-						"A10"
+						"A16"
 					],
 					"query": [
 						{


### PR DESCRIPTION
Updated A10 examples in bash and postman. No more remaining references to A10.